### PR TITLE
Removed aliyuncs.com (not a ddns)

### DIFF
--- a/dynamic-dns/domains
+++ b/dynamic-dns/domains
@@ -100,7 +100,6 @@ alexandravlad.com
 alexlan.org
 alfa145.com
 alimentoshen.cl
-aliyuncs.com
 allaround.hk
 allez.la
 allisons.org


### PR DESCRIPTION
Removed `aliyuncs.com` (not a ddns)
https://github.com/nextdns/ddns-domains/issues/2#issuecomment-3609096234